### PR TITLE
fix gpio installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,10 @@
 #! /usr/bin/sh
 # Install all dependencies and setup radioglobe service to run under default user
-sudo apt install vlc pulseaudio python3-pip python3-smbus python3-dev python3-rpi.gpio
+sudo apt install vlc pulseaudio python3-pip python3-smbus python3-dev python3-rpi-lgpio
 pip3 install https://github.com/pl31/python-liquidcrystal_i2c/archive/master.zip
 pip3 install python-vlc
 pip3 install spidev
+
 # Set paths according to username
 sed -i "s/USER/${USER}/g" services/*.service
 sudo cp services/*.service /etc/systemd/system


### PR DESCRIPTION
While installing the software on a rasperry pi 3B+ I bumped into the error below: 

```
File "/home/pi/work/RadioGlobe/button.py", line 18, in __init__
  	GPIO.add_event_detect(self.pin, GPIO.FALLING, callback=self.start_timer, bouncetime=150)
RuntimeError: Failed to add edge detection
```

I fixed by changing the line to install the gpio library. I replaced the line 

```
sudo apt install vlc pulseaudio python3-pip python3-smbus python3-dev python3-rpi.gpio
```

by

```
sudo apt install vlc pulseaudio python3-pip python3-smbus python3-dev python3-rpi-lgpio
```

Thanks for the amazing work on the radio globe !!